### PR TITLE
ims-ext-common: Forward the legacy getAutoReject call to

### DIFF
--- a/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -629,6 +629,11 @@ public class QtiImsExtUtils {
         android.provider.Settings.Global.putInt(contentResolver,
                 QtiCallConstants.IMS_AUTO_REJECT + phoneId, value);
     }
+    
+    // Obtain compatibility with older ims.apk and forward the old call to the new method
+    public static int getAutoReject(ContentResolver contentResolver, int phoneId) {
+        return getAutoRejectMode(contentResolver, phoneId);
+    }
 
     // Supported for multi sim only. Default value is disabled
     public static int getAutoReject(ContentResolver contentResolver, int phoneId) {


### PR DESCRIPTION
 obtain compatibility with older ims.apk

* commit 8000c1e changed and renamed the getAutoReject method
  to getAutoRejectMode. ims.apk depends on that method and since the new method takes the same
  parameters just forward calls to the old method to the new renamed one. This might obtain
  compatibility with older ims.apk's.

Change-Id: If83119b0089861ae8d14981ee37772cc95d20586