### PR TITLE
Upstream telephony from caf

### DIFF
--- a/ims/ims-ext-common/src/org/codeaurora/ims/QtiCallConstants.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/QtiCallConstants.java
@@ -311,15 +311,22 @@ public class QtiCallConstants {
     // Recorder Auto-Scaling Factor
     public static final int RECORDER_SCALING_FACTOR = 8;
 
+    // Refer to ImsConfigImplBase CONFIG_RESULT_* codes
+    public static final int CONFIG_RESULT_NOT_SUPPORTED = 2;
     /**
-     * Whether auto reject is enabled for IMS calls on a sub when high priority data
+     * Auto reject call options - for IMS calls on a sub when high priority data
      * is on the other sub
-     * Type: int (0 for disabled, 1 for enabled)
+     * Type: int (0 for default, 1 for auto reject, 2 for allow alerting)
      */
-    public static final String IMS_AUTO_REJECT = "qti.settings.auto_reject";
-    // Auto reject call modes
-    public static final int AUTO_REJECT_CALL_DISABLED = 0;
-    public static final int AUTO_REJECT_CALL_ENABLED = 1;
+    public static final String IMS_AUTO_REJECT_MODE = "qti.settings.auto_reject";
+    // auto reject call modes
+    // user is notified of incoming call
+    public static final int AR_MODE_ALLOW_INCOMING = 0;
+    // incoming call is auto rejected
+    public static final int AR_MODE_AUTO_REJECT = 1;
+    // user is usually alerted of incoming call but auto rejected in certain cases
+    // modem may have some optimization
+    public static final int AR_MODE_ALLOW_ALERTING = 2;
     // Auto reject call UI item, avoid conflicting values from ImsCallUtils.ConfigItem
     public static final int AUTO_REJECT_CALL_MODE = 1000;
     public static final int QTI_CONFIG_SMS_APP = 1001;

--- a/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -76,6 +76,23 @@ public class QtiImsExtUtils {
     public static final String QTI_IMS_STATIC_IMAGE_SETTING =
             "ims_vt_call_static_image";
 
+    /* name for call transfer setting */
+    private static final String IMS_CALL_TRANSFER_SETTING = "ims_call_transfer";
+
+    /**
+     * Definitions for the call transfer type. For easier implementation,
+     * the transfer type is defined as a bit mask value.
+     */
+    //Value representing blind call transfer type
+    public static final int QTI_IMS_BLIND_TRANSFER = 0x01;
+    //Value representing assured call transfer type
+    public static final int QTI_IMS_ASSURED_TRANSFER = 0x02;
+    //Value representing consultative call transfer type
+    public static final int QTI_IMS_CONSULTATIVE_TRANSFER = 0x04;
+
+    /* Call transfer extra key */
+    public static final String QTI_IMS_TRANSFER_EXTRA_KEY = "transferType";
+
     /* Ims phoneId extra key */
     public static final String QTI_IMS_PHONE_ID_EXTRA_KEY = "phoneId";
 
@@ -370,6 +387,15 @@ public class QtiImsExtUtils {
      */
     public static boolean shallShowVideoQuality(int phoneId, Context context) {
         return isCarrierConfigEnabled(phoneId, context, QtiCarrierConfigs.SHOW_VIDEO_QUALITY_UI);
+    }
+
+    /***
+     * Checks if the IMS call transfer property is enabled or not.
+     * Returns true if enabled, or false otherwise.
+     */
+    public static boolean isCallTransferEnabled(Context context) {
+        return Settings.Global.getInt(context.getContentResolver(), IMS_CALL_TRANSFER_SETTING, 0)
+                == 1;
     }
 
    /**

--- a/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -595,20 +595,19 @@ public class QtiImsExtUtils {
                 QtiCarrierConfigs.KEY_CARRIER_CANCEL_MODIFY_CALL_SUPPORTED));
     }
 
-    // Supported for multi sim only. Allows user to enable or disable auto rejecting IMS MT calls
+    // Supported for multi sim only. Allows user to set auto reject call mode for IMS MT calls
     // when high priority data is on the other sub
-    public static void setAutoReject(ContentResolver contentResolver, int phoneId, boolean turnOn) {
-        final int value = turnOn ? QtiCallConstants.AUTO_REJECT_CALL_ENABLED :
-                QtiCallConstants.AUTO_REJECT_CALL_DISABLED;
+    public static void setAutoRejectMode(ContentResolver contentResolver, int phoneId,
+            int arMode) {
         android.provider.Settings.Global.putInt(contentResolver,
-                QtiCallConstants.IMS_AUTO_REJECT + phoneId, value);
+                QtiCallConstants.IMS_AUTO_REJECT_MODE + phoneId, arMode);
     }
 
-    // Supported for multi sim only. Default value is disabled
-    public static int getAutoReject(ContentResolver contentResolver, int phoneId) {
+    // Supported for multi sim only.
+    public static int getAutoRejectMode(ContentResolver contentResolver, int phoneId) {
         return android.provider.Settings.Global.getInt(contentResolver,
-                QtiCallConstants.IMS_AUTO_REJECT + phoneId,
-                QtiCallConstants.AUTO_REJECT_CALL_DISABLED);
+                QtiCallConstants.IMS_AUTO_REJECT_MODE + phoneId,
+                QtiCallConstants.AR_MODE_ALLOW_INCOMING);
     }
 
     public static boolean canAcceptAsOneWayVideo(int phoneId, Context context) {
@@ -635,6 +634,6 @@ public class QtiImsExtUtils {
     public static int getCallComposerMode(ContentResolver contentResolver, int phoneId) {
         return android.provider.Settings.Global.getInt(contentResolver,
                 QtiCallConstants.IMS_CALL_COMPOSER + phoneId,
-                QtiCallConstants.AUTO_REJECT_CALL_DISABLED);
+                QtiCallConstants.CALL_COMPOSER_DISABLED);
     }
 }

--- a/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -629,6 +629,11 @@ public class QtiImsExtUtils {
                 QtiCallConstants.IMS_AUTO_REJECT_MODE + phoneId, arMode);
     }
 
+    // Obtain compatibility with older ims.apk and forward the old call to the new method
+    public static int getAutoReject(ContentResolver contentResolver, int phoneId) {
+        return getAutoRejectMode(contentResolver, phoneId);
+    }
+
     // Supported for multi sim only.
     public static int getAutoRejectMode(ContentResolver contentResolver, int phoneId) {
         return android.provider.Settings.Global.getInt(contentResolver,

--- a/internal/src/org/codeaurora/internal/IExtTelephony.aidl
+++ b/internal/src/org/codeaurora/internal/IExtTelephony.aidl
@@ -39,6 +39,7 @@ import org.codeaurora.internal.Token;
 import org.codeaurora.internal.DcParam;
 import org.codeaurora.internal.INetworkCallback;
 import org.codeaurora.internal.Client;
+import org.codeaurora.internal.NrConfig;
 
 /**
  * Interface used to interact with the telephony framework for
@@ -434,5 +435,28 @@ interface IExtTelephony {
     * @return - string value assigned
     */
     String getPropertyValueString(String property, String def);
+
+    /**
+    * Set nr config to NSA/SA/NSA+SA on a given slotId.
+    * @param - slotId
+    * @param - def
+    *        NR_CONFIG_INVALID  - invalid config
+    *        NR_CONFIG_COMBINED_SA_NSA - set to NSA+SA
+    *        NR_CONFIG_NSA - set to NSA
+    *        NR_CONFIG_SA - set to SA
+    *  @param - client registered with packagename to receive
+    *         callbacks.
+    * @return Integer Token to be used to compare with the response.
+    */
+    Token setNrConfig(int slotId, in NrConfig def, in Client client);
+
+    /**
+    * Query current nr config on a given slotId.
+    * @param - slotId
+    *  @param - client registered with packagename to receive
+    *         callbacks.
+    * @return Integer Token to be used to compare with the response.
+    */
+    Token queryNrConfig(int slotId, in Client client);
 
 }

--- a/internal/src/org/codeaurora/internal/INetworkCallback.aidl
+++ b/internal/src/org/codeaurora/internal/INetworkCallback.aidl
@@ -36,6 +36,7 @@ import org.codeaurora.internal.Status;
 import org.codeaurora.internal.Token;
 import org.codeaurora.internal.BearerAllocationStatus;
 import org.codeaurora.internal.UpperLayerIndInfo;
+import org.codeaurora.internal.NrConfig;
 import org.codeaurora.internal.NrConfigType;
 import org.codeaurora.internal.NrIconType;
 
@@ -71,6 +72,7 @@ interface INetworkCallback {
 
     /**
     * @deprecated
+    * use onNrConfigStatus instead to get current nr config.
     */
     void on5gConfigInfo(int slotId, in Token token, in Status status,
             in NrConfigType nrConfigType);
@@ -94,4 +96,21 @@ interface INetworkCallback {
     * @param - enableStatus true if endce is enabled otherwise false
     */
     void onEndcStatus(int slotId, in Token token, in Status status, boolean enableStatus);
+
+    /**
+    * Response to setNrConfig
+    * @param - slotId
+    * @param - token is the same token which is recived in setNrConfig
+    * @param - status SUCCESS/FAILURE based on the modem Result code
+    */
+    void onSetNrConfig(int slotId, in Token token, in Status status);
+
+    /**
+    * Response to queryNrConfig
+    * @param - slotId
+    * @param - token is the same token which is recived in queryNrConfig
+    * @param - status SUCCESS/FAILURE based on the modem Result code
+    * @param - nrConfig: NSA + SA/NSA/SA
+    */
+    void onNrConfigStatus(int slotId, in Token token, in Status status, in NrConfig nrConfig);
 }

--- a/internal/src/org/codeaurora/internal/NetworkCallbackBase.java
+++ b/internal/src/org/codeaurora/internal/NetworkCallbackBase.java
@@ -37,6 +37,7 @@ import org.codeaurora.internal.SignalStrength;
 import org.codeaurora.internal.DcParam;
 import org.codeaurora.internal.Status;
 import org.codeaurora.internal.Token;
+import org.codeaurora.internal.NrConfig;
 import org.codeaurora.internal.NrConfigType;
 import org.codeaurora.internal.BearerAllocationStatus;
 import org.codeaurora.internal.UpperLayerIndInfo;
@@ -113,6 +114,20 @@ public class NetworkCallbackBase extends INetworkCallback.Stub {
         Log.d(TAG,
                 "onEndcStatus: slotId = " + slotId + " token = " + token + " " + "status" +
                         status + " enableStatus = " + enableStatus);
+    }
+
+    @Override
+    public void onSetNrConfig(int slotId, Token token, Status status) throws
+            RemoteException {
+        Log.d(TAG, "onSetNrConfig: slotId = " + slotId + " token = " + token + " status" +
+                status);
+    }
+
+    @Override
+    public void onNrConfigStatus(int slotId, Token token, Status status, NrConfig nrConfig) throws
+            RemoteException {
+        Log.d(TAG, "onNrConfigStatus: slotId = " + slotId + " token = " + token + " status" +
+                status + " NrConfig = " + nrConfig);
     }
 
 }

--- a/internal/src/org/codeaurora/internal/NrConfig.aidl
+++ b/internal/src/org/codeaurora/internal/NrConfig.aidl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package org.codeaurora.internal;
+
+parcelable NrConfig;

--- a/internal/src/org/codeaurora/internal/NrConfig.java
+++ b/internal/src/org/codeaurora/internal/NrConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package org.codeaurora.internal;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class NrConfig implements Parcelable{
+    private static final String TAG = "NrConfig";
+
+    public static final int NR_CONFIG_INVALID = -1;
+    public static final int NR_CONFIG_COMBINED_SA_NSA = 0;
+    public static final int NR_CONFIG_NSA =  1;
+    public static final int NR_CONFIG_SA =  2;
+
+    private int mValue;
+
+    public NrConfig(int val) {
+        mValue = val;
+    }
+
+    public NrConfig(Parcel in) {
+        mValue = in.readInt();
+    }
+
+    public int get() {
+        return mValue;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public void writeToParcel(Parcel out, int flags) {
+        out.writeInt(mValue);
+    }
+
+    public static final Parcelable.Creator<NrConfig> CREATOR = new Parcelable.Creator() {
+        public NrConfig createFromParcel(Parcel in) {
+            return new NrConfig(in);
+        }
+
+        public NrConfig[] newArray(int size) {
+            return new NrConfig[size];
+        }
+    };
+
+    public void readFromParcel(Parcel in) {
+        mValue = in.readInt();
+    }
+
+    @Override
+    public String toString() {
+        return TAG + ": " + get();
+    }
+}


### PR DESCRIPTION
ims-ext-common: Forward the legacy getAutoReject call to 
Revert "IMS: Remove API and constants related to ECT." 
Merge tag 'LA.QSSI.11.0.r1-09400-qssi.0' of https://source.codeaurora
Merge 8000c1e on remote branch
Modify APIs to allow 3rd option for Auto Reject
Merge "Add APIs to set and query NR config."
Add APIs to set and query NR config.
Merge f726fed on remote branch
Merge da40ef6 on remote branch


